### PR TITLE
调整组件查找逻辑

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ avalon.oniui的注释文档生成器
 
 #### 运行
 
-一、没有参数
+一、扫描当前目录
 
-    $ avalon-doc
+    $ avalon-doc --all
 
 扫描当前目录下所有目录，并查找是否存在avalon组件，并生成文档。组件命名规则及生成文件目录格式为：
 
@@ -29,9 +29,9 @@ avalon.oniui的注释文档生成器
 
 二、指定目录
 
-    $ avalon-doc /home/workspace/oniui
+    $ avalon-doc /home/workspace/oniui/at
 
-扫描指定目录下的所有目录
+以指定目录的目录名为组件名，执行生成
 
 ---
 

--- a/doc.js
+++ b/doc.js
@@ -37,7 +37,6 @@ exports.main = function (path) {
 exports.handleExtension = handleExtension;
 
 function handleExtension(dir, name) {
-    console.log('docgen avalon.' + name + '.js');
     var content, program;
     try {
         content = fs.readFileSync(dir + '/avalon.' + name + '.js', 'utf8');
@@ -49,6 +48,7 @@ function handleExtension(dir, name) {
     } catch (e) {
         return;
     }
+    console.log('docgen avalon.' + name + '.js');
     // get names from first comment.
     var comments = program.comments, index = 0,
         TYPE_LINE = 'Line', TYPE_BLOCK = 'Block';
@@ -334,6 +334,8 @@ function handleExtension(dir, name) {
 }
 if (process.mainModule === module) {
     if (process.argv.length === 2) {
+        console.log('Usage: avalon-doc [directory|js file|--all]');
+    } else if (process.argv[2] === '--all') {
         exports.main(".");
     } else {
         var path = process.argv[2],
@@ -342,9 +344,11 @@ if (process.mainModule === module) {
             var dir = m[1] ? path.substr(0, path.length - m[0].length) : '.';
             exports.handleExtension(dir, m[2]);
         } else if (fs.statSync(path).isDirectory()) {
-            exports.main(path);
+            //exports.main(path);
+            if (path[path.length - 1] === '/') path = path.substr(0, path.length - 1);
+            exports.handleExtension(path, path.substr(path.lastIndexOf('/') + 1));
         } else {
-            console.log('Usage: avalon.docgen [path|js file]');
+            console.log('Usage: avalon-doc [directory|js file|--all]');
         }
     }
 }


### PR DESCRIPTION
- 添加了`--all`参数用来扫描全部组件
- 现在通过文件夹路径指定运行目录时不再进行扫描，而是根据文件夹名称查找全部文件
